### PR TITLE
Add Ruby 3.4 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This action reads your gemspec and provides an output of compatible Ruby version
 A static list of compatible versions is maintained.
 This is a subset of [setup-ruby's supported versions](https://github.com/ruby/setup-ruby#supported-versions).
 
+* 3.4
 * 3.3
 * 3.2
 * 3.1

--- a/extract_compatible_ruby_versions
+++ b/extract_compatible_ruby_versions
@@ -4,6 +4,7 @@ require 'json'
 require 'rubygems'
 
 VERSIONS = [
+  '3.4',
   '3.3',
   '3.2',
   '3.1',


### PR DESCRIPTION
Should this go into a V1 branch, because it will add Ruby 3.4 jobs, which might fail for downstream users?