### PR TITLE
Reflect the transfer to voxpupuli/ruby-version

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ jobs:
       ruby: ${{ steps.ruby.outputs.versions }}
     steps:
       - id: ruby
-        uses: ekohl/ruby-version@v0
+        uses: voxpupuli/ruby-version@v0
 
   test:
     name: "Ruby ${{ matrix.ruby }}"


### PR DESCRIPTION

This repository is now maintained under the Vox Pupuli umbrella and users should no longer use the old name.
