### PR TITLE
Add Ruby 4.0 support

### DIFF
--- a/extract_compatible_ruby_versions
+++ b/extract_compatible_ruby_versions
@@ -4,6 +4,7 @@ require 'json'
 require 'rubygems'
 
 VERSIONS = [
+  '4.0',
   '3.4',
   '3.3',
   '3.2',


### PR DESCRIPTION
This adds Ruby 4.0 to our matrix. Right now all of our gems use the v1 branch. This specific PR goes to a new branch, v2.